### PR TITLE
Add `bugs.url` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "keywords": ["netlify", "netlify-plugin", "prisma", "database"],
   "main": "src/index.js",
   "repository": "git@github.com:redwoodjs/netlify-plugin-prisma-provider.git",
-  "bugs": "",
+  "bugs": {
+    "url": "https://github.com/redwoodjs/netlify-plugin-prisma-provider/issues"
+  },
   "author": "rob@prestonwernerventures.com",
   "license": "MIT",
   "private": false


### PR DESCRIPTION
When a `bugs` property is present in the `package.json`, Netlify displays the URL to users when an error happened inside the plugin, so users can report that error directly.

This PR adds this property.